### PR TITLE
Avoid update failure

### DIFF
--- a/src/element.tsx
+++ b/src/element.tsx
@@ -15,6 +15,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
     ) => {
         const player = useContext(VFXContext);
         const ref = useRef<HTMLElement>(null);
+        const elementDidAdd = useRef<boolean>(false);
 
         // Create scene
         useEffect(() => {
@@ -24,7 +25,9 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
             }
 
             const shader = props.shader;
-            player?.addElement(element, { shader });
+            player?.addElement(element, { shader })?.then(() => {
+                elementDidAdd.current = true;
+            });
 
             return () => {
                 player?.removeElement(element);
@@ -33,7 +36,7 @@ function VFXElementFactory<T extends keyof JSX.IntrinsicElements>(
 
         // Rerender if the content is updated
         useEffect(() => {
-            if (ref.current === null) {
+            if (ref.current === null || elementDidAdd.current === false) {
                 return;
             }
 


### PR DESCRIPTION
Because player.addElement is asynchronous, player.updateElement can be called before the element is added to player.

In that case, player.updateElement just returns a `Promise.reject()`, and it is recorded as an error of `Uncaught (in promise) undefined` in web console.

This change makes VFXElement track addition of its element and
call player.updateElement only if element is added.